### PR TITLE
質問ページにページネイトを実装する

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -2,6 +2,8 @@ class QuestionsController < ApplicationController
   before_action :set_question, only: %i(show edit update destroy)
 
   def index
+    @sort_type = params[:sort] || 'newest'
+    @questions = Question.sort_type_is(@sort_type).page(params[:page]).includes(:user)
   end
 
   def show

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,5 +1,5 @@
 class QuestionsController < ApplicationController
-  before_action :set_question, only: %i(show edit update destroy)
+  before_action :set_question, only: %i(show)
 
   def index
     @sort_type = params[:sort] || 'newest'

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,5 @@
 module ApplicationHelper
-  def is_active_actions(param_name)
-    params[:param_name].present? ? "active" : nil
+  def is_active_params(param_name)
+    @sort_type == param_name ? "active" : ""
   end
-
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def is_active_actions(param_name)
+    params[:param_name].present? ? "active" : nil
+  end
+
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,16 +6,16 @@ class Question < ApplicationRecord
   belongs_to :user
   has_many :answers, dependent: :destroy
 
-  scope :recent_with_user, -> {
-    includes([:user, :taggings]).order(created_at: :desc)
+  scope :recent_with_user, -> (page){
+    includes([:user, :taggings]).order(created_at: :desc).page(page)
   }
 
-  scope :weighted_total, -> {
-    order(cached_weighted_total: :desc)
+  scope :weighted_total, -> (page) {
+    includes(:user).order(cached_weighted_total: :desc).page(page)
   }
 
-  scope :no_answers, -> {
-    where(answers_count: 0).order(:created_at)
+  scope :no_answers, -> (page){
+    includes(:user).where(answers_count: 0).order(:created_at).page(page)
   }
 
   scope :with_tagged_questions, lambda {|tag_name|

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -6,20 +6,19 @@ class Question < ApplicationRecord
   belongs_to :user
   has_many :answers, dependent: :destroy
 
-  scope :recent_with_user, -> (page){
-    includes([:user, :taggings]).order(created_at: :desc).page(page)
-  }
-
-  scope :weighted_total, -> (page) {
-    includes(:user).order(cached_weighted_total: :desc).page(page)
-  }
-
-  scope :no_answers, -> (page){
-    includes(:user).where(answers_count: 0).order(:created_at).page(page)
-  }
-
   scope :with_tagged_questions, lambda {|tag_name|
     includes(:user).tagged_with(tag_name).order(created_at: :desc)
+  }
+
+  scope :sort_type_is, -> (type) {
+    case type
+    when 'no_answer'
+      where(answers_count: 0).order(:created_at)
+    when 'votes'
+      order(cached_votes_score: :desc)
+    else
+      order(created_at: :desc)
+    end
   }
 
   def truncated_content

--- a/app/views/questions/_question_list.html.haml
+++ b/app/views/questions/_question_list.html.haml
@@ -20,4 +20,4 @@
           .user_stat= render "shared/user_stat", user: question.user
   %hr
 
-=paginate questions, param_name: 'page_recent'
+=paginate questions, params: {controller: 'questions'}

--- a/app/views/questions/_question_list.html.haml
+++ b/app/views/questions/_question_list.html.haml
@@ -19,3 +19,5 @@
           .published_at= "質問日時: #{question.humanize_created_at}"
           .user_stat= render "shared/user_stat", user: question.user
   %hr
+
+=paginate questions, param_name: 'page_recent'

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -11,21 +11,13 @@
 
   %ul.nav.nav-tabs{role:"tab_list"}
     %li.nav-item{role: "presentation"}
-      %a.nav-link{class: "#{is_active_actions('newer')}", aria:{controls:"tab_a", selected: true}, data:{toggle:"tab"}, href: "#tab_a", role: "tab"}
-        新着
+      = link_to '新着', questions_path(sort: 'newest'), class: "nav-link #{is_active_params('newest')}"
     %li.nav-item{role:"presentation"}
-      %a.nav-link{class: "#{is_active_actions('votes')}", aria:{controls:"tab_b"}, data:{toggle:"tab"}, href: "#tab_b", role: "tab"}
-        得票数
+      = link_to '得票数', questions_path(sort: 'votes'), class: "nav-link #{is_active_params('votes')}"
     %li.nav-item{role:"presentation"}
-      %a.nav-link{class: "#{is_active_actions('no_answer')}", aria:{controls:"tab_c"}, data:{toggle:"tab"}, href: "#tab_c", role: "tab"}
-        未回答
+      = link_to '未回答', questions_path(sort: 'no_answer'), class: "nav-link #{is_active_params('no_answer')}"
+
   .tab-content
-    .tab-pane#tab_a.active{role:"tab_panel"}
+    .tab-pane.active{role:"tab_panel"}
       %p
-        =render "question_list", questions: Question.recent_with_user(params[:page_recent])
-    .tab-pane#tab_b{role:"tab_panel"}
-      %p
-        =render "question_list", questions: Question.weighted_total(params[:page_votes])
-    .tab-pane#tab_c{role:"tab_panel"}
-      %p
-        =render "question_list", questions: Question.no_answers(params[:page_no_answer])
+        =render "question_list", questions: @questions

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -11,21 +11,21 @@
 
   %ul.nav.nav-tabs{role:"tab_list"}
     %li.nav-item{role: "presentation"}
-      %a.nav-link.active{aria:{controls:"tab_a", selected: true}, data:{toggle:"tab"}, href: "#tab_a", role: "tab"}
+      %a.nav-link{class: "#{is_active_actions('newer')}", aria:{controls:"tab_a", selected: true}, data:{toggle:"tab"}, href: "#tab_a", role: "tab"}
         新着
     %li.nav-item{role:"presentation"}
-      %a.nav-link{aria:{controls:"tab_b"}, data:{toggle:"tab"}, href: "#tab_b", role: "tab"}
+      %a.nav-link{class: "#{is_active_actions('votes')}", aria:{controls:"tab_b"}, data:{toggle:"tab"}, href: "#tab_b", role: "tab"}
         得票数
     %li.nav-item{role:"presentation"}
-      %a.nav-link{aria:{controls:"tab_c"}, data:{toggle:"tab"}, href: "#tab_c", role: "tab"}
+      %a.nav-link{class: "#{is_active_actions('no_answer')}", aria:{controls:"tab_c"}, data:{toggle:"tab"}, href: "#tab_c", role: "tab"}
         未回答
   .tab-content
     .tab-pane#tab_a.active{role:"tab_panel"}
       %p
-        =render "question_list", questions: Question.recent_with_user
+        =render "question_list", questions: Question.recent_with_user(params[:page_recent])
     .tab-pane#tab_b{role:"tab_panel"}
       %p
-        =render "question_list", questions: Question.weighted_total
+        =render "question_list", questions: Question.weighted_total(params[:page_votes])
     .tab-pane#tab_c{role:"tab_panel"}
       %p
-        =render "question_list", questions: Question.no_answers
+        =render "question_list", questions: Question.no_answers(params[:page_no_answer])


### PR DESCRIPTION
- タブごとの切り替えをパラメータで分岐させる
- `?sort=newer&page=2`のようにアクティブなタブとページ数をパラメータで決定する