### PR TITLE
Usersにカラム追加、ユーザープロフィール、Questionに対するテスト

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'acts-as-taggable-on'
 gem 'acts_as_votable'
 
 gem 'ransack'
+gem 'simple_form'
 gem 'kaminari'
 gem 'initial_avatar'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,9 @@ GEM
     selenium-webdriver (3.142.0)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
+    simple_form (4.1.0)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-commands-rspec (1.0.4)
@@ -363,6 +366,7 @@ DEPENDENCIES
   rubocop (~> 0.69.0)
   sassc-rails
   selenium-webdriver
+  simple_form
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)

--- a/app/assets/stylesheets/application.sass
+++ b/app/assets/stylesheets/application.sass
@@ -9,3 +9,8 @@
   width: 32px
   height: 32px
   //border-radius: 50%
+
+.avatar-profile
+  width: 64px
+  height: 64px
+  border-radius: 5%

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -3,7 +3,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
 private
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: %i(name introduce live_in))
+    devise_parameter_sanitizer.permit(:account_update, keys: %i(name introduce live_in))
   end
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,16 +2,16 @@
 %h2
   アカウント情報更新
 
-%ul.nav.nav-tabs{ role:"tab_list" }
+%ul.nav.nav-tabs{ role: "tab_list" }
   %li.nav-item{ role: "presentation" }
     = link_to 'プロフィール', user_path(@user), class: "nav-link"
 
-  %li.nav-item{ role:"presentation" }
+  %li.nav-item{ role: "presentation" }
     = link_to 'プロフィールを編集', edit_user_registration_path, class: "nav-link active"
 
   .tab-content
-    .tab-pane.active{ role:"tab_panel" }
-      = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role:"form" }) do |f|
+    .tab-pane.active{ role: "tab_panel" }
+      = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role: "form" }) do |f|
         = devise_error_messages!
         .form-group
           = f.label :name

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -6,34 +6,27 @@
 
 .tab-content
   .tab-pane.active{ role: "tab_panel" }
-    = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role: "form" }) do |f|
+    = simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role: "form" }) do |f|
       = devise_error_messages!
       .form-group
-        = f.label :name
-        = f.text_field :name, :autofocus => true, class: "form-control"
+        = f.input :name, :autofocus => true, input_html: { class: "form-control" }
       .form-group
-        = f.label :introduce
-        = f.text_area :introduce, class: "form-control"
+        = f.input :introduce, input_html: { class: "form-control" }
       .form-group
-        = f.label :live_in
-        = f.text_field :live_in, class: "form-control"
+        = f.input :live_in, input_html: { class: "form-control" }
       .form-group
-        = f.label :email
-        = f.email_field :email, class: "form-control"
+        = f.input :email, input_html: { class: "form-control" }
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
         .form-control
-          Currently waiting confirmation for: #{resource.unconfirmed_email}
+          メールアドレスの確認を待っています: #{resource.unconfirmed_email}
       .form-group
-        = f.label :password
         %i (パスワードを変更しない場合は空欄のままにしてください)
-        = f.password_field :password, :autocomplete => "off", class: "form-control"
+        = f.input :password, :autocomplete => "off", input_html: { class: "form-control" }
       .form-group
-        = f.label :password_confirmation
-        = f.password_field :password_confirmation, class: "form-control"
+        = f.input :password_confirmation, input_html: { class: "form-control" }
       .form-group
-        = f.label :current_password
         %i (更新するために現在のパスワードが必要です。)
-        = f.password_field :current_password, class: "form-control"
+        = f.input :current_password, input_html: { class: "form-control" }
       .form-group
         = f.submit "更新", class: "btn btn-primary"
 %h3 退会

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -6,16 +6,16 @@
 
 .tab-content
   .tab-pane.active{ role: "tab_panel" }
-    = simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role: "form" }) do |f|
+    = simple_form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, role: "form" }) do |f|
       = devise_error_messages!
-      = f.input :name, :autofocus => true
+      = f.input :name, autofocus: true
       = f.input :introduce
       = f.input :live_in
       = f.input :email
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
         メールアドレスの確認を待っています: #{resource.unconfirmed_email}
       %i (パスワードを変更しない場合は空欄のままにしてください)
-      = f.input :password, :autocomplete => "off"
+      = f.input :password, autocomplete: "off"
       = f.input :password_confirmation
       %i (更新するために現在のパスワードが必要です。)
       = f.input :current_password
@@ -23,5 +23,5 @@
 %hr
 %h3 退会
 %p
-  退会してユーザー情報を削除しますか？ #{button_to "退会する", registration_path(resource_name), :data => { :confirm => "よろしいですか？" }, :method => :delete, class: "btn btn-danger"}
+  退会してユーザー情報を削除しますか？ #{button_to "退会する", registration_path(resource_name), data: { confirm: "よろしいですか？" }, method: :delete, class: "btn btn-danger"}
 = link_to "戻る", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,30 +1,46 @@
 
 %h2
   アカウント情報更新
-= form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role:"form" }) do |f|
-  = devise_error_messages!
-  .form-group
-    = f.label :name
-    = f.text_field :name, :autofocus => true, class:"form-control"
-  .form-group
-    = f.label :email
-    = f.email_field :email, class:"form-control"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    .form-control
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .form-group
-    = f.label :password
-    %i (パスワードを変更しない場合は空欄のままにしてください)
-    = f.password_field :password, :autocomplete => "off", class:"form-control"
-  .form-group
-    = f.label :password_confirmation
-    = f.password_field :password_confirmation, class:"form-control"
-  .form-group
-    = f.label :current_password
-    %i (更新するために現在のパスワードが必要です。)
-    = f.password_field :current_password, class:"form-control"
-  .form-group
-    = f.submit "更新", class:"btn btn-primary"
+
+%ul.nav.nav-tabs{ role:"tab_list" }
+  %li.nav-item{ role: "presentation" }
+    = link_to 'プロフィール', user_path(@user), class: "nav-link"
+
+  %li.nav-item{ role:"presentation" }
+    = link_to 'プロフィールを編集', edit_user_registration_path, class: "nav-link active"
+
+  .tab-content
+    .tab-pane.active{ role:"tab_panel" }
+      = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role:"form" }) do |f|
+        = devise_error_messages!
+        .form-group
+          = f.label :name
+          = f.text_field :name, :autofocus => true, class:"form-control"
+        .form-group
+          = f.label :introduce
+          = f.text_area :introduce, class:"form-control"
+        .form-group
+          = f.label :live_in
+          = f.text_field :live_in, class:"form-control"
+        .form-group
+          = f.label :email
+          = f.email_field :email, class:"form-control"
+        - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+          .form-control
+            Currently waiting confirmation for: #{resource.unconfirmed_email}
+        .form-group
+          = f.label :password
+          %i (パスワードを変更しない場合は空欄のままにしてください)
+          = f.password_field :password, :autocomplete => "off", class:"form-control"
+        .form-group
+          = f.label :password_confirmation
+          = f.password_field :password_confirmation, class:"form-control"
+        .form-group
+          = f.label :current_password
+          %i (更新するために現在のパスワードが必要です。)
+          = f.password_field :current_password, class:"form-control"
+        .form-group
+          = f.submit "更新", class:"btn btn-primary"
 %h3 退会
 %p
   退会してユーザー情報を削除しますか？ #{button_to "退会する", registration_path(resource_name), :data => { :confirm => "よろしいですか？" }, :method => :delete, class:"btn btn-danger"}

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -15,33 +15,33 @@
         = devise_error_messages!
         .form-group
           = f.label :name
-          = f.text_field :name, :autofocus => true, class:"form-control"
+          = f.text_field :name, :autofocus => true, class: "form-control"
         .form-group
           = f.label :introduce
-          = f.text_area :introduce, class:"form-control"
+          = f.text_area :introduce, class: "form-control"
         .form-group
           = f.label :live_in
-          = f.text_field :live_in, class:"form-control"
+          = f.text_field :live_in, class: "form-control"
         .form-group
           = f.label :email
-          = f.email_field :email, class:"form-control"
+          = f.email_field :email, class: "form-control"
         - if devise_mapping.confirmable? && resource.pending_reconfirmation?
           .form-control
             Currently waiting confirmation for: #{resource.unconfirmed_email}
         .form-group
           = f.label :password
           %i (パスワードを変更しない場合は空欄のままにしてください)
-          = f.password_field :password, :autocomplete => "off", class:"form-control"
+          = f.password_field :password, :autocomplete => "off", class: "form-control"
         .form-group
           = f.label :password_confirmation
-          = f.password_field :password_confirmation, class:"form-control"
+          = f.password_field :password_confirmation, class: "form-control"
         .form-group
           = f.label :current_password
           %i (更新するために現在のパスワードが必要です。)
-          = f.password_field :current_password, class:"form-control"
+          = f.password_field :current_password, class: "form-control"
         .form-group
-          = f.submit "更新", class:"btn btn-primary"
+          = f.submit "更新", class: "btn btn-primary"
 %h3 退会
 %p
-  退会してユーザー情報を削除しますか？ #{button_to "退会する", registration_path(resource_name), :data => { :confirm => "よろしいですか？" }, :method => :delete, class:"btn btn-danger"}
+  退会してユーザー情報を削除しますか？ #{button_to "退会する", registration_path(resource_name), :data => { :confirm => "よろしいですか？" }, :method => :delete, class: "btn btn-danger"}
 = link_to "戻る", :back

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -2,45 +2,40 @@
 %h2
   アカウント情報更新
 
-%ul.nav.nav-tabs{ role: "tab_list" }
-  %li.nav-item{ role: "presentation" }
-    = link_to 'プロフィール', user_path(@user), class: "nav-link"
+= render 'layouts/profile', user: @user, active_show: false
 
-  %li.nav-item{ role: "presentation" }
-    = link_to 'プロフィールを編集', edit_user_registration_path, class: "nav-link active"
-
-  .tab-content
-    .tab-pane.active{ role: "tab_panel" }
-      = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role: "form" }) do |f|
-        = devise_error_messages!
-        .form-group
-          = f.label :name
-          = f.text_field :name, :autofocus => true, class: "form-control"
-        .form-group
-          = f.label :introduce
-          = f.text_area :introduce, class: "form-control"
-        .form-group
-          = f.label :live_in
-          = f.text_field :live_in, class: "form-control"
-        .form-group
-          = f.label :email
-          = f.email_field :email, class: "form-control"
-        - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-          .form-control
-            Currently waiting confirmation for: #{resource.unconfirmed_email}
-        .form-group
-          = f.label :password
-          %i (パスワードを変更しない場合は空欄のままにしてください)
-          = f.password_field :password, :autocomplete => "off", class: "form-control"
-        .form-group
-          = f.label :password_confirmation
-          = f.password_field :password_confirmation, class: "form-control"
-        .form-group
-          = f.label :current_password
-          %i (更新するために現在のパスワードが必要です。)
-          = f.password_field :current_password, class: "form-control"
-        .form-group
-          = f.submit "更新", class: "btn btn-primary"
+.tab-content
+  .tab-pane.active{ role: "tab_panel" }
+    = form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role: "form" }) do |f|
+      = devise_error_messages!
+      .form-group
+        = f.label :name
+        = f.text_field :name, :autofocus => true, class: "form-control"
+      .form-group
+        = f.label :introduce
+        = f.text_area :introduce, class: "form-control"
+      .form-group
+        = f.label :live_in
+        = f.text_field :live_in, class: "form-control"
+      .form-group
+        = f.label :email
+        = f.email_field :email, class: "form-control"
+      - if devise_mapping.confirmable? && resource.pending_reconfirmation?
+        .form-control
+          Currently waiting confirmation for: #{resource.unconfirmed_email}
+      .form-group
+        = f.label :password
+        %i (パスワードを変更しない場合は空欄のままにしてください)
+        = f.password_field :password, :autocomplete => "off", class: "form-control"
+      .form-group
+        = f.label :password_confirmation
+        = f.password_field :password_confirmation, class: "form-control"
+      .form-group
+        = f.label :current_password
+        %i (更新するために現在のパスワードが必要です。)
+        = f.password_field :current_password, class: "form-control"
+      .form-group
+        = f.submit "更新", class: "btn btn-primary"
 %h3 退会
 %p
   退会してユーザー情報を削除しますか？ #{button_to "退会する", registration_path(resource_name), :data => { :confirm => "よろしいですか？" }, :method => :delete, class: "btn btn-danger"}

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -8,27 +8,19 @@
   .tab-pane.active{ role: "tab_panel" }
     = simple_form_for(resource, :as => resource_name, :url => registration_path(resource_name), :html => { :method => :put, role: "form" }) do |f|
       = devise_error_messages!
-      .form-group
-        = f.input :name, :autofocus => true, input_html: { class: "form-control" }
-      .form-group
-        = f.input :introduce, input_html: { class: "form-control" }
-      .form-group
-        = f.input :live_in, input_html: { class: "form-control" }
-      .form-group
-        = f.input :email, input_html: { class: "form-control" }
+      = f.input :name, :autofocus => true
+      = f.input :introduce
+      = f.input :live_in
+      = f.input :email
       - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-        .form-control
-          メールアドレスの確認を待っています: #{resource.unconfirmed_email}
-      .form-group
-        %i (パスワードを変更しない場合は空欄のままにしてください)
-        = f.input :password, :autocomplete => "off", input_html: { class: "form-control" }
-      .form-group
-        = f.input :password_confirmation, input_html: { class: "form-control" }
-      .form-group
-        %i (更新するために現在のパスワードが必要です。)
-        = f.input :current_password, input_html: { class: "form-control" }
-      .form-group
-        = f.submit "更新", class: "btn btn-primary"
+        メールアドレスの確認を待っています: #{resource.unconfirmed_email}
+      %i (パスワードを変更しない場合は空欄のままにしてください)
+      = f.input :password, :autocomplete => "off"
+      = f.input :password_confirmation
+      %i (更新するために現在のパスワードが必要です。)
+      = f.input :current_password
+      = f.submit "更新", class: "btn btn-primary"
+%hr
 %h3 退会
 %p
   退会してユーザー情報を削除しますか？ #{button_to "退会する", registration_path(resource_name), :data => { :confirm => "よろしいですか？" }, :method => :delete, class: "btn btn-danger"}

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -5,26 +5,26 @@
   = devise_error_messages!
   .form-group
     = f.label :name
-    = f.text_field :name, :autofocus => true, class:"form-control"
+    = f.text_field :name, :autofocus => true, class: "form-control"
 
   .form-group
     = f.label :email
     %br
-    = f.email_field :email, autocomplete: "email", class:"form-control"
+    = f.email_field :email, autocomplete: "email", class: "form-control"
 
   .form-group
     = f.label :password
     - if @minimum_password_length
       %i (#{@minimum_password_length}文字以上）
     %br
-    = f.password_field :password, autocomplete: "new-password", class:"form-control"
+    = f.password_field :password, autocomplete: "new-password", class: "form-control"
 
   .form-group
     = f.label :password_confirmation
     %br
-    = f.password_field :password_confirmation, autocomplete: "new-password", class:"form-control"
+    = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control"
 
   .form-group
-    = f.submit "登録する", class:"btn btn-primary"
+    = f.submit "登録する", class: "btn btn-primary"
 
 = render "devise/shared/links"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,28 +1,17 @@
 %h2
   ユーザー登録
 
-= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
+= simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = devise_error_messages!
-  .form-group
-    = f.label :name
-    = f.text_field :name, :autofocus => true, class: "form-control"
+  = f.input :name, :autofocus => true
+  = f.input :email, autocomplete: "email"
 
-  .form-group
-    = f.label :email
-    %br
-    = f.email_field :email, autocomplete: "email", class: "form-control"
+  - if @minimum_password_length
+    %i (#{@minimum_password_length}文字以上）
+  %br
+  = f.input :password, autocomplete: "new-password"
 
-  .form-group
-    = f.label :password
-    - if @minimum_password_length
-      %i (#{@minimum_password_length}文字以上）
-    %br
-    = f.password_field :password, autocomplete: "new-password", class: "form-control"
-
-  .form-group
-    = f.label :password_confirmation
-    %br
-    = f.password_field :password_confirmation, autocomplete: "new-password", class: "form-control"
+  = f.input :password_confirmation, autocomplete: "new-password"
 
   .form-group
     = f.submit "登録する", class: "btn btn-primary"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -3,7 +3,7 @@
 
 = simple_form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = devise_error_messages!
-  = f.input :name, :autofocus => true
+  = f.input :name, autofocus: true
   = f.input :email, autocomplete: "email"
 
   - if @minimum_password_length

--- a/app/views/layouts/_profile.html.haml
+++ b/app/views/layouts/_profile.html.haml
@@ -1,0 +1,7 @@
+%ul.nav.nav-tabs{ role: "tab_list" }
+  %li.nav-item{ role: "presentation" }
+    = link_to 'プロフィール', user_path(user), class: active_show ? "nav-link active" :  "nav-link"
+
+  - if current_user == user
+    %li.nav-item{ role: "presentation" }
+      = link_to 'プロフィールを編集', edit_user_registration_path, class: !active_show ? "nav-link active" :  "nav-link"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
+    %meta{content: "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}/
     %title SokutoRails
     = csrf_meta_tags
     = csp_meta_tag

--- a/app/views/layouts/mailer.html.haml
+++ b/app/views/layouts/mailer.html.haml
@@ -1,7 +1,7 @@
 !!!
 %html
   %head
-    %meta{:content => "text/html; charset=utf-8", "http-equiv" => "Content-Type"}/
+    %meta{content: "text/html; charset=utf-8", "http-equiv" => "Content-Type"}/
     :css
       /* Email styles need to be inline */
   %body

--- a/app/views/loggedin/questions/_form.html.haml
+++ b/app/views/loggedin/questions/_form.html.haml
@@ -1,15 +1,15 @@
-= form_with( model: [:loggedin, question], local: true) do |f|
+= simple_form_for([:loggedin, question]) do |f|
   - if question.errors.any?
     #error_explanation.alert.alert-danger
       %ul
         - question.errors.full_messages.each do |message|
           %li= message
   .field
-    = f.text_field :title, placeholder: "質問のタイトル", class: 'form-control'
+    = f.input :title, placeholder: "質問のタイトル", input_html: { class: 'form-control' }
   .field.mt-1
-    = f.text_field :tag_list, value: question.tags.pluck(:name).join(","), placeholder: "タグ（カンマで区切ります）", class: 'form-control'
+    = f.input :tag_list, value: question.tags.pluck(:name).join(","), placeholder: "タグ１,tag2", input_html: { class: 'form-control' }
   .field
-    = f.text_area :content, placeholder: "質問の内容", class: 'form-control'
+    = f.input :content, placeholder: "質問の内容", input_html: { class: 'form-control' }
 
   .actions
     = f.submit submit_label, class: 'btn btn-primary mt-1'

--- a/app/views/loggedin/questions/_form.html.haml
+++ b/app/views/loggedin/questions/_form.html.haml
@@ -4,12 +4,9 @@
       %ul
         - question.errors.full_messages.each do |message|
           %li= message
-  .field
-    = f.input :title, placeholder: "質問のタイトル", input_html: { class: 'form-control' }
-  .field.mt-1
-    = f.input :tag_list, value: question.tags.pluck(:name).join(","), placeholder: "タグ１,tag2", input_html: { class: 'form-control' }
-  .field
-    = f.input :content, placeholder: "質問の内容", input_html: { class: 'form-control' }
+  = f.input :title, placeholder: "質問のタイトル"
+  = f.input :tag_list, value: question.tags.pluck(:name).join(","), placeholder: "タグ１,tag2"
+  = f.input :content, placeholder: "質問の内容"
 
   .actions
     = f.submit submit_label, class: 'btn btn-primary mt-1'

--- a/app/views/questions/index.html.haml
+++ b/app/views/questions/index.html.haml
@@ -8,16 +8,16 @@
     .col-5
       %h3 すべての質問
 %hr
-  %ul.nav.nav-tabs{ role:"tab_list" }
+  %ul.nav.nav-tabs{ role: "tab_list" }
     %li.nav-item{ role: "presentation" }
       = link_to '新着', questions_path(query: 'newest'), class: "nav-link #{active('newest')}"
-    %li.nav-item{ role:"presentation" }
+    %li.nav-item{ role: "presentation" }
       = link_to '得票数', questions_path(query: 'votes'), class: "nav-link #{active('votes')}"
-    %li.nav-item{ role:"presentation" }
+    %li.nav-item{ role: "presentation" }
       = link_to '未回答', questions_path(query: 'no_answer'), class: "nav-link #{active('no_answer')}"
 
   .tab-content
-    .tab-pane.active{ role:"tab_panel" }
+    .tab-pane.active{ role: "tab_panel" }
       %p
         = render @questions
   = paginate @questions

--- a/app/views/questions/show.html.haml
+++ b/app/views/questions/show.html.haml
@@ -1,6 +1,6 @@
-%h1=@question.title
+%h1.title=@question.title
 
-= render @question.tags
+.tags= render @question.tags
 
 .container.mt-2
   .row

--- a/app/views/questions/show.html.haml
+++ b/app/views/questions/show.html.haml
@@ -1,4 +1,4 @@
-%h1.title=@question.title
+%h1.title{ data: { test: 'question_title'} }=@question.title
 
 .tags= render @question.tags
 

--- a/app/views/questions/show.html.haml
+++ b/app/views/questions/show.html.haml
@@ -1,4 +1,4 @@
-%h1.title{ data: { test: 'question_title'} }=@question.title
+%h1.title=@question.title
 
 .tags= render @question.tags
 

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,9 +1,19 @@
-%h1
-  = avatar_image @user, class: 'avatar-square'
-  = @user.name
+%ul.nav.nav-tabs{ role:"tab_list" }
+  %li.nav-item{ role: "presentation" }
+    = link_to 'プロフィール', user_path(@user), class: "nav-link active"
 
-- if current_user == @user
-  = link_to 'プロフィール編集', edit_user_registration_path, class: 'btn btn-primary'
-= @user.email
+  - if current_user == @user
+    %li.nav-item{ role:"presentation" }
+      = link_to 'プロフィールを編集', edit_user_registration_path, class: "nav-link"
 
-= render @user.questions
+.tab-content
+  .tab-pane.active{ role:"tab_panel" }
+    .row.mt-3
+      .col-3
+        = avatar_image @user, class: 'avatar-profile'
+      .col-9
+        %h3= @user.name
+        .introduce= @user.introduce
+        .live_in= @user.live_in
+        = render @user.questions.includes(%i(tags tag_taggings))
+

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,10 +1,4 @@
-%ul.nav.nav-tabs{ role: "tab_list" }
-  %li.nav-item{ role: "presentation" }
-    = link_to 'プロフィール', user_path(@user), class: "nav-link active"
-
-  - if current_user == @user
-    %li.nav-item{ role: "presentation" }
-      = link_to 'プロフィールを編集', edit_user_registration_path, class: "nav-link"
+= render 'layouts/profile', user: @user, active_show: true
 
 .tab-content
   .tab-pane.active{ role: "tab_panel" }

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,13 +1,13 @@
-%ul.nav.nav-tabs{ role:"tab_list" }
+%ul.nav.nav-tabs{ role: "tab_list" }
   %li.nav-item{ role: "presentation" }
     = link_to 'プロフィール', user_path(@user), class: "nav-link active"
 
   - if current_user == @user
-    %li.nav-item{ role:"presentation" }
+    %li.nav-item{ role: "presentation" }
       = link_to 'プロフィールを編集', edit_user_registration_path, class: "nav-link"
 
 .tab-content
-  .tab-pane.active{ role:"tab_panel" }
+  .tab-pane.active{ role: "tab_panel" }
     .row.mt-3
       .col-3
         = avatar_image @user, class: 'avatar-profile'

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -1,0 +1,179 @@
+# frozen_string_literal: true
+#
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components to know
+# more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+#
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Wrappers are used by the form builder to generate a
+  # complete input. You can remove any component from the
+  # wrapper, change the order or even add your own to the
+  # stack. The options given below are used to wrap the
+  # whole input.
+  config.wrappers :default, class: :input,
+                  hint_class:      :field_with_hint, error_class: :field_with_errors, valid_class: :field_without_errors do |b|
+    ## Extensions enabled by default
+    # Any of these extensions can be disabled for a
+    # given input by passing: `f.input EXTENSION_NAME => false`.
+    # You can make any of these extensions optional by
+    # renaming `b.use` to `b.optional`.
+
+    # Determines whether to use HTML5 (:email, :url, ...)
+    # and required attributes
+    b.use :html5
+
+    # Calculates placeholders automatically from I18n
+    # You can also pass a string as f.input placeholder: "Placeholder"
+    b.use :placeholder
+
+    ## Optional extensions
+    # They are disabled unless you pass `f.input EXTENSION_NAME => true`
+    # to the input. If so, they will retrieve the values from the model
+    # if any exists. If you want to enable any of those
+    # extensions by default, you can change `b.optional` to `b.use`.
+
+    # Calculates maxlength from length validations for string inputs
+    # and/or database column lengths
+    b.optional :maxlength
+
+    # Calculate minlength from length validations for string inputs
+    b.optional :minlength
+
+    # Calculates pattern from format validations for string inputs
+    b.optional :pattern
+
+    # Calculates min and max from length validations for numeric inputs
+    b.optional :min_max
+
+    # Calculates readonly automatically from readonly attributes
+    b.optional :readonly
+
+    ## Inputs
+    # b.use :input, class: 'input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label_input
+    b.use :hint, wrap_with: { tag: :span, class: :hint }
+    b.use :error, wrap_with: { tag: :span, class: :error }
+
+    ## full_messages_for
+    # If you want to display the full error message for the attribute, you can
+    # use the component :full_error, like:
+    #
+    # b.use :full_error, wrap_with: { tag: :span, class: :error }
+  end
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :default
+
+  # Define the way to render check boxes / radio buttons with labels.
+  # Defaults to :nested for bootstrap config.
+  #   inline: input + label
+  #   nested: label > input
+  config.boolean_style = :nested
+
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # Use :to_sentence to list all errors for each field.
+  # config.error_method = :first
+
+  # Default tag used for error notification helper.
+  config.error_notification_tag = :div
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'error_notification'
+
+  # Series of attempts to detect a default label method for collection.
+  # config.collection_label_methods = [ :to_label, :name, :title, :to_s ]
+
+  # Series of attempts to detect a default value method for collection.
+  # config.collection_value_methods = [ :id, :to_s ]
+
+  # You can wrap a collection of radio/check boxes in a pre-defined tag, defaulting to none.
+  # config.collection_wrapper_tag = nil
+
+  # You can define the class to use on all collection wrappers. Defaulting to none.
+  # config.collection_wrapper_class = nil
+
+  # You can wrap each item in a collection of radio/check boxes with a tag,
+  # defaulting to :span.
+  # config.item_wrapper_tag = :span
+
+  # You can define a class to use in all item wrappers. Defaulting to none.
+  # config.item_wrapper_class = nil
+
+  # How the label text should be generated altogether with the required text.
+  # config.label_text = lambda { |label, required, explicit_label| "#{required} #{label}" }
+
+  # You can define the class to use on all labels. Default is nil.
+  # config.label_class = nil
+
+  # You can define the default class to be used on forms. Can be overriden
+  # with `html: { :class }`. Defaulting to none.
+  # config.default_form_class = nil
+
+  # You can define which elements should obtain additional classes
+  # config.generate_additional_classes_for = [:wrapper, :label, :input]
+
+  # Whether attributes are required by default (or not). Default is true.
+  # config.required_by_default = true
+
+  # Tell browsers whether to use the native HTML5 validations (novalidate form option).
+  # These validations are enabled in SimpleForm's internal config but disabled by default
+  # in this configuration, which is recommended due to some quirks from different browsers.
+  # To stop SimpleForm from generating the novalidate option, enabling the HTML5 validations,
+  # change this configuration to true.
+  config.browser_validations = false
+
+  # Collection of methods to detect if a file type was given.
+  # config.file_methods = [ :mounted_as, :file?, :public_filename, :attached? ]
+
+  # Custom mappings for input types. This should be a hash containing a regexp
+  # to match as key, and the input type that will be used when the field name
+  # matches the regexp as value.
+  # config.input_mappings = { /count/ => :integer }
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  # config.wrapper_mappings = { string: :prepend }
+
+  # Namespaces where SimpleForm should look for custom input classes that
+  # override default inputs.
+  # config.custom_inputs_namespaces << "CustomInputs"
+
+  # Default priority for time_zone inputs.
+  # config.time_zone_priority = nil
+
+  # Default priority for country inputs.
+  # config.country_priority = nil
+
+  # When false, do not use translations for labels.
+  # config.translate_labels = true
+
+  # Automatically discover new inputs in Rails' autoload path.
+  # config.inputs_discovery = true
+
+  # Cache SimpleForm inputs discovery
+  # config.cache_discovery = !Rails.env.development?
+
+  # Default class for inputs
+  # config.input_class = nil
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'checkbox'
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  # config.include_default_input_wrapper_class = true
+
+  # Defines which i18n scope will be used in Simple Form.
+  # config.i18n_scope = 'simple_form'
+
+  # Defines validation classes to the input_field. By default it's nil.
+  # config.input_field_valid_class = 'is-valid'
+  # config.input_field_error_class = 'is-invalid'
+end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -1,0 +1,439 @@
+# frozen_string_literal: true
+
+# Please do not make direct changes to this file!
+# This generator is maintained by the community around simple_form-bootstrap:
+# https://github.com/rafaelfranca/simple_form-bootstrap
+# All future development, tests, and organization should happen there.
+# Background history: https://github.com/plataformatec/simple_form/issues/1561
+
+# Uncomment this and change the path if necessary to include your own
+# components.
+# See https://github.com/plataformatec/simple_form#custom-components
+# to know more about custom components.
+# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+
+# Use this setup block to configure all options available in SimpleForm.
+SimpleForm.setup do |config|
+  # Default class for buttons
+  config.button_class = 'btn'
+
+  # Define the default class of the input wrapper of the boolean input.
+  config.boolean_label_class = 'form-check-label'
+
+  # How the label text should be generated altogether with the required text.
+  config.label_text = lambda { |label, required, explicit_label| "#{label} #{required}" }
+
+  # Define the way to render check boxes / radio buttons with labels.
+  config.boolean_style = :inline
+
+  # You can wrap each item in a collection of radio/check boxes with a tag
+  config.item_wrapper_tag = :div
+
+  # Defines if the default input wrapper class should be included in radio
+  # collection wrappers.
+  config.include_default_input_wrapper_class = false
+
+  # CSS class to add for error notification helper.
+  config.error_notification_class = 'alert alert-danger'
+
+  # Method used to tidy up errors. Specify any Rails Array method.
+  # :first lists the first message for each field.
+  # :to_sentence to list all errors for each field.
+  config.error_method = :to_sentence
+
+  # add validation classes to `input_field`
+  config.input_field_error_class = 'is-invalid'
+  config.input_field_valid_class = 'is-valid'
+
+
+  # vertical forms
+  #
+  # vertical default_wrapper
+  config.wrappers :vertical_form, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'form-control-label'
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical input for boolean
+  config.wrappers :vertical_boolean, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :form_check_wrapper, tag: 'div', class: 'form-check' do |bb|
+      bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'form-check-label'
+      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # vertical input for radio buttons and check boxes
+  config.wrappers :vertical_collection, item_wrapper_class: 'form-check', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical input for inline radio buttons and check boxes
+  config.wrappers :vertical_collection_inline, item_wrapper_class: 'form-check form-check-inline', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical file input
+  config.wrappers :vertical_file, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label
+    b.use :input, class: 'form-control-file', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical multi select
+  config.wrappers :vertical_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'form-control-label'
+    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
+      ba.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    end
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # vertical range input
+  config.wrappers :vertical_range, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label
+    b.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+
+  # horizontal forms
+  #
+  # horizontal default_wrapper
+  config.wrappers :horizontal_form, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 col-form-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal input for boolean
+  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper tag: 'label', class: 'col-sm-3' do |ba|
+      ba.use :label_text
+    end
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |wr|
+      wr.wrapper :form_check_wrapper, tag: 'div', class: 'form-check' do |bb|
+        bb.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+        bb.use :label, class: 'form-check-label'
+        bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+        bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+      end
+    end
+  end
+
+  # horizontal input for radio buttons and check boxes
+  config.wrappers :horizontal_collection, item_wrapper_class: 'form-check', tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 form-control-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal input for inline radio buttons and check boxes
+  config.wrappers :horizontal_collection_inline, item_wrapper_class: 'form-check form-check-inline', tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 form-control-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal file input
+  config.wrappers :horizontal_file, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 form-control-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal multi select
+  config.wrappers :horizontal_multi_select, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'col-sm-3 control-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |bb|
+        bb.use :input, class: 'form-control mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+      end
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # horizontal range input
+  config.wrappers :horizontal_range, tag: 'div', class: 'form-group row', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label, class: 'col-sm-3 form-control-label'
+    b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
+      ba.use :input, class: 'form-control-range', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+      ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+
+  # inline forms
+  #
+  # inline default_wrapper
+  config.wrappers :inline_form, tag: 'span', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :label, class: 'sr-only'
+
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # inline input for boolean
+  config.wrappers :inline_boolean, tag: 'span', class: 'form-check flex-wrap justify-content-start mr-sm-2', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :input, class: 'form-check-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: 'form-check-label'
+    b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+
+  # bootstrap custom forms
+  #
+  # custom input for boolean
+  config.wrappers :custom_boolean, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :form_check_wrapper, tag: 'div', class: 'custom-control custom-checkbox' do |bb|
+      bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'custom-control-label'
+      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  config.wrappers :custom_boolean_switch, tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :form_check_wrapper, tag: 'div', class: 'custom-control custom-checkbox-switch' do |bb|
+      bb.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      bb.use :label, class: 'custom-control-label'
+      bb.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+      bb.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+    end
+  end
+
+  # custom input for radio buttons and check boxes
+  config.wrappers :custom_collection, item_wrapper_class: 'custom-control', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom input for inline radio buttons and check boxes
+  config.wrappers :custom_collection_inline, item_wrapper_class: 'custom-control custom-control-inline', tag: 'fieldset', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.wrapper :legend_tag, tag: 'legend', class: 'col-form-label pt-0' do |ba|
+      ba.use :label_text
+    end
+    b.use :input, class: 'custom-control-input', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom file input
+  config.wrappers :custom_file, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :readonly
+    b.use :label, class: 'form-control-label'
+    b.wrapper :custom_file_wrapper, tag: 'div', class: 'custom-file' do |ba|
+      ba.use :input, class: 'custom-file-input', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :label, class: 'custom-file-label'
+      ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    end
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom multi select
+  config.wrappers :custom_multi_select, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :label, class: 'form-control-label'
+    b.wrapper tag: 'div', class: 'd-flex flex-row justify-content-between align-items-center' do |ba|
+      ba.use :input, class: 'custom-select mx-1', error_class: 'is-invalid', valid_class: 'is-valid'
+    end
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom range input
+  config.wrappers :custom_range, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :readonly
+    b.optional :step
+    b.use :label, class: 'form-control-label'
+    b.use :input, class: 'custom-range', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+
+  # Input Group - custom component
+  # see example app and config at https://github.com/rafaelfranca/simple_form-bootstrap
+  # config.wrappers :input_group, tag: 'div', class: 'form-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+  #   b.use :html5
+  #   b.use :placeholder
+  #   b.optional :maxlength
+  #   b.optional :minlength
+  #   b.optional :pattern
+  #   b.optional :min_max
+  #   b.optional :readonly
+  #   b.use :label, class: 'form-control-label'
+  #   b.wrapper :input_group_tag, tag: 'div', class: 'input-group' do |ba|
+  #     ba.optional :prepend
+  #     ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+  #     ba.optional :append
+  #   end
+  #   b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
+  #   b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  # end
+
+
+  # Floating Labels form
+  #
+  # floating labels default_wrapper
+  config.wrappers :floating_labels_form, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.optional :maxlength
+    b.optional :minlength
+    b.optional :pattern
+    b.optional :min_max
+    b.optional :readonly
+    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: 'form-control-label'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+  # custom multi select
+  config.wrappers :floating_labels_select, tag: 'div', class: 'form-label-group', error_class: 'form-group-invalid', valid_class: 'form-group-valid' do |b|
+    b.use :html5
+    b.optional :readonly
+    b.use :input, class: 'custom-select custom-select-lg', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :label, class: 'form-control-label'
+    b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
+    b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
+  end
+
+
+  # The default wrapper to be used by the FormBuilder.
+  config.default_wrapper = :vertical_form
+
+  # Custom wrappers for input types. This should be a hash containing an input
+  # type as key and the wrapper that will be used for all inputs with specified type.
+  config.wrapper_mappings = {
+      boolean:       :vertical_boolean,
+      check_boxes:   :vertical_collection,
+      date:          :vertical_multi_select,
+      datetime:      :vertical_multi_select,
+      file:          :vertical_file,
+      radio_buttons: :vertical_collection,
+      range:         :vertical_range,
+      time:          :vertical_multi_select
+  }
+
+  # enable custom form wrappers
+  # config.wrapper_mappings = {
+  #   boolean:       :custom_boolean,
+  #   check_boxes:   :custom_collection,
+  #   date:          :custom_multi_select,
+  #   datetime:      :custom_multi_select,
+  #   file:          :custom_file,
+  #   radio_buttons: :custom_collection,
+  #   range:         :custom_range,
+  #   time:          :custom_multi_select
+  # }
+end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -18,6 +18,7 @@ ja:
         id: ID
         title: タイトル
         content: 質問の内容
+        tag_list: タグ（カンマで区切ります）
         created_at: 登録日時
         updated_at: 更新日時
       answer:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -27,8 +27,10 @@ ja:
   helpers:
     label:
       user:
-        name: 名前
+        name: 表示名
         email: メールアドレス
+        introduce: 自己紹介
+        live_in: 場所
         password: パスワード
         password_confirmation: パスワード（確認）
         remember_me: パスワードを記憶

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -24,6 +24,16 @@ ja:
         content: 回答
         created_at: 登録日時
         updated_at: 更新日時
+  simple_form:
+    labels:
+      user:
+        name: 表示名
+        email: メールアドレス
+        introduce: 自己紹介
+        live_in: 場所
+        password: パスワード
+        password_confirmation: パスワード（確認）
+        remember_me: パスワードを記憶
   helpers:
     label:
       user:

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -1,0 +1,31 @@
+en:
+  simple_form:
+    "yes": 'Yes'
+    "no": 'No'
+    required:
+      text: 'required'
+      mark: '*'
+      # You can uncomment the line below if you need to overwrite the whole required html.
+      # When using html, text and mark won't be used.
+      # html: '<abbr title="required">*</abbr>'
+    error_notification:
+      default_message: "Please review the problems below:"
+    # Examples
+    # labels:
+    #   defaults:
+    #     password: 'Password'
+    #   user:
+    #     new:
+    #       email: 'E-mail to sign in.'
+    #     edit:
+    #       email: 'E-mail.'
+    # hints:
+    #   defaults:
+    #     username: 'User name to sign in.'
+    #     password: 'No special characters, please.'
+    # include_blanks:
+    #   defaults:
+    #     age: 'Rather not say'
+    # prompts:
+    #   defaults:
+    #     age: 'Select your age'

--- a/db/migrate/20190624074117_add_profile_to_users.rb
+++ b/db/migrate/20190624074117_add_profile_to_users.rb
@@ -1,0 +1,6 @@
+class AddProfileToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :introduce, :text, default: '', null: false
+    add_column :users, :live_in, :string, default: '', null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_05_100512) do
+ActiveRecord::Schema.define(version: 2019_06_24_074117) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -80,6 +80,8 @@ ActiveRecord::Schema.define(version: 2019_04_05_100512) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
+    t.text "introduce", default: "", null: false
+    t.string "live_in", default: "", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/templates/haml/scaffold/_form.html.haml
+++ b/lib/templates/haml/scaffold/_form.html.haml
@@ -1,0 +1,12 @@
+-# frozen_string_literal: true
+= simple_form_for(@<%= singular_table_name %>) do |f|
+  = f.error_notification
+  = f.error_notification message: f.object.errors[:base].to_sentence if f.object.errors[:base].present?
+
+  .form-inputs
+  <%- attributes.each do |attribute| -%>
+    = f.<%= attribute.reference? ? :association : :input %> :<%= attribute.name %>
+  <%- end -%>
+
+  .form-actions
+    = f.button :submit

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -22,4 +22,10 @@ RSpec.configure do |config|
 
   Dir[Rails.root.join('spec/support/*.rb')].each {|f| require f}
   config.include RequestSpecHelper, type: :system
+
+  config.before(:each) do |example|
+    if example.metadata[:type] == :system
+      driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+    end
+  end
 end

--- a/spec/support/devise.rb
+++ b/spec/support/devise.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.include Warden::Test::Helpers
+end

--- a/spec/support/request_spec_helper.rb
+++ b/spec/support/request_spec_helper.rb
@@ -1,6 +1,4 @@
 module RequestSpecHelper
-  include Warden::Test::Helpers
-
   def self.included(base)
     base.before(:each) { Warden.test_mode! }
     base.after(:each) { Warden.test_reset! }

--- a/spec/system/question_spec.rb
+++ b/spec/system/question_spec.rb
@@ -11,14 +11,14 @@ RSpec.feature "Questions", type: :system do
       visit root_path
       click_on '質問する'
 
-      fill_in 'question[title]', with: 'プログラマーにとって大切なことはなんですか'
-      fill_in 'question[tag_list]', with: '職業, プログラマー, 考え方'
-      fill_in 'question[content]', with: 'プロのプログラマーを続けていく上で、あなたが大切にしている考えや、心がけていることなどあれば教えてください。'
+      fill_in 'タイトル', with: 'プログラマーにとって大切なことはなんですか'
+      fill_in 'タグ（カンマで区切ります）', with: '職業, プログラマー, 考え方'
+      fill_in '質問の内容', with: 'プロのプログラマーを続けていく上で、あなたが大切にしている考えや、心がけていることなどあれば教えてください。'
 
       click_on '投稿する'
 
       expect(page).to have_content '質問「プログラマーにとって大切なことはなんですか」を作成しました'
-      expect(page).to have_selector 'h1.title', text: 'プログラマーにとって大切なことはなんですか'
+      expect(page).to have_selector "[data-test='question_title']", text: 'プログラマーにとって大切なことはなんですか'
       expect(page).to have_selector '.tags', text: '職業 プログラマー 考え方'
       expect(page).to have_selector '.content', text: 'プロのプログラマーを続けていく上で、あなたが大切にしている考えや、心がけていることなどあれば教えてください。'
     end

--- a/spec/system/question_spec.rb
+++ b/spec/system/question_spec.rb
@@ -18,9 +18,9 @@ RSpec.feature "Questions", type: :system do
       click_on '投稿する'
 
       expect(page).to have_content '質問「プログラマーにとって大切なことはなんですか」を作成しました'
-      expect(page).to have_selector "[data-test='question_title']", text: 'プログラマーにとって大切なことはなんですか'
-      expect(page).to have_selector '.tags', text: '職業 プログラマー 考え方'
-      expect(page).to have_selector '.content', text: 'プロのプログラマーを続けていく上で、あなたが大切にしている考えや、心がけていることなどあれば教えてください。'
+      expect(page).to have_content 'プログラマーにとって大切なことはなんですか'
+      expect(page).to have_content '職業 プログラマー 考え方'
+      expect(page).to have_content 'プロのプログラマーを続けていく上で、あなたが大切にしている考えや、心がけていることなどあれば教えてください。'
     end
   end
 end

--- a/spec/system/question_spec.rb
+++ b/spec/system/question_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+RSpec.feature "Questions", type: :system do
+
+  let!(:user) { create(:user) }
+
+  feature 'ログインユーザーは質問を作れる' do
+    before { sign_in user }
+
+    scenario '質問の作成' do
+      visit root_path
+      click_on '質問する'
+
+      fill_in 'question[title]', with: 'プログラマーにとって大切なことはなんですか'
+      fill_in 'question[tag_list]', with: '職業, プログラマー, 考え方'
+      fill_in 'question[content]', with: 'プロのプログラマーを続けていく上で、あなたが大切にしている考えや、心がけていることなどあれば教えてください。'
+
+      click_on '投稿する'
+
+      expect(page).to have_content '質問「プログラマーにとって大切なことはなんですか」を作成しました'
+      expect(page).to have_selector 'h1.title', text: 'プログラマーにとって大切なことはなんですか'
+      expect(page).to have_selector '.tags', text: '職業 プログラマー 考え方'
+      expect(page).to have_selector '.content', text: 'プロのプログラマーを続けていく上で、あなたが大切にしている考えや、心がけていることなどあれば教えてください。'
+    end
+  end
+end


### PR DESCRIPTION
fix #50 

- Usersのカラムに`introduce`, `live_in`を追加しました
- ユーザープロフィール画面を追加しました
- Questionの作成テストを追加しました

「プロフィール」と「プロフィール編集」をタブで表示させ、それぞれ`users#show`/`users/registrations#edit`に遷移するようにしました。